### PR TITLE
Fixed some tests and removed the redundant ones

### DIFF
--- a/test/test.js
+++ b/test/test.js
@@ -564,24 +564,6 @@ describe('primus-multiplex', function (){
         fn('thanks');
       });
     });
-
-    it('should work if emitter is initialized after multiplex', function (done) {
-        
-      primus.use('emitter', 'primus-emitter');
-
-      var a = primus.channel('a');
-      srv.listen(function () {
-        a.on('connection', function (spark) {
-          spark.send('msg', { hi: 'hello' });
-        });
-      });
-      var cl = client(srv, primus)
-        , cla = cl.channel('a');
-      cla.on('msg', function (msg) {
-        expect(msg).to.be.eql({ hi: 'hello' });
-        done();
-      });
-    });
   });
 
   describe('primus-rooms', function () {
@@ -1091,21 +1073,6 @@ describe('primus-multiplex', function (){
           if ('end' === data) cla.end();
         });
       });
-    });
-
-    it('should work if rooms is initialized after multiplex', function (done) {
-      primus.use('rooms', 'primus-rooms');
-
-      var a = primus.channel('a');
-      srv.listen(function () {
-        a.on('connection', function (spark) {
-          spark.join('a', function () {
-            done();
-          });
-        });
-      });
-      var cl = client(srv, primus)
-        , cla = cl.channel('a');
     });
   });
 


### PR DESCRIPTION
This will apply the same fixes already applied here  cayasso/primus-rooms#16.

Test `'should work if emitter is initialized after multiplex'` was equivalent to test `'should allow sending message from server to client'`.

Test `'should work if rooms is initialized after multiplex'` was equivalent to test `'should allow joining a room'`.
