### PR TITLE
add 'subscribe' and 'unsubscribe' events to multiplex sockets, to allow ...

### DIFF
--- a/lib/server/channel.js
+++ b/lib/server/channel.js
@@ -107,6 +107,7 @@ Channel.prototype.subscribe = function subscribe(conn, id) {
   this.connections[spark.id] = spark;
   conn.channels[this.name] = conn.channels[this.name] || [];
   conn.channels[this.name].push(spark.id);
+  conn.emit('subscribe', this.name, spark);
   return this;
 };
 
@@ -114,7 +115,7 @@ Channel.prototype.subscribe = function subscribe(conn, id) {
  * Unsubscribe a connection from this `channel`.
  *
  * @param {String|Number} id The connection id.
- * @param {Booleanr} ignore
+ * @param {Boolean} ignore
  * @return {Channel} this
  * @api private
  */
@@ -122,7 +123,10 @@ Channel.prototype.subscribe = function subscribe(conn, id) {
 Channel.prototype.unsubscribe = function unsubscribe(id, ignore) {
   var spark = this.connections[id];
   if (spark) {
-    if (!ignore) spark.end();
+    if (!ignore) {
+      spark.conn.emit('unsubscribe', this.name, spark);
+      spark.end();
+    }
     delete this.connections[id];
   }
   return this;

--- a/lib/server/multiplex.js
+++ b/lib/server/multiplex.js
@@ -99,7 +99,9 @@ Multiplex.prototype.onconnection = function onconnection(conn) {
       , payload = data.shift()
       , channel = mp.channels[escape(name)];
 
-    if (!channel) return false;
+    if (!channel) {
+        channel = mp.channel(name)
+    }
 
     switch (type) {
 
@@ -136,7 +138,7 @@ Multiplex.prototype.ondisconnection = function ondisconnection(conn) {
     i = 0; l = ids.length;
     if (name in this.channels) {
       chnl = this.channels[name];
-      for (; i < l; ++i) {        
+      for (; i < l; ++i) {
         spark = chnl.connections[ids[i]];
         if (spark) spark.end();
       }

--- a/test/test.js
+++ b/test/test.js
@@ -60,7 +60,7 @@ describe('primus-multiplex', function (){
     srv.listen();
   });
 
-  it('should stablish a connection', function (done) {
+  it('should establish a connection', function (done) {
     this.timeout(0);
 
     var a = primus.channel('a');
@@ -85,6 +85,36 @@ describe('primus-multiplex', function (){
 
     var cl = client(srv, primus);
     var ca = cl.channel('a');
+  });
+
+  it('should create channel dynamically and fire subscribe', function (done) {
+    primus.on('connection', function(spark) {
+      spark.on('subscribe', function(channelName, channelSpark) {
+        expect(channelName).to.be('a');
+        expect(channelSpark).to.be.ok();
+        done();
+      });
+    });
+    srv.listen();
+
+    var cl = client(srv, primus);
+    cl.channel('a');
+  });
+
+  it('should fire unsubscribe upon close', function (done) {
+    primus.on('connection', function(spark) {
+      spark.on('subscribe', function(channelName, channelSpark) {
+        spark.on('unsubscribe', function(channelName, channelSpark) {
+          expect(channelName).to.be('a');
+          expect(channelSpark).to.be.ok();
+          done();
+        });
+      });
+    });
+    srv.listen();
+
+    var cl = client(srv, primus);
+    cl.channel('a').end();
   });
 
   it('should allow sending message from client to server', function (done) {


### PR DESCRIPTION
...and leverage dynamic channel creation.

In reference to already filed issue [#12](https://github.com/cayasso/primus-multiplex/issues/12).
