### PR TITLE
Updating the list of proxied events

### DIFF
--- a/lib/client/spark.js
+++ b/lib/client/spark.js
@@ -6,8 +6,9 @@ module.exports = function spark() {
 
   'use strict';
 
-  var Stream
-    , nextTick;
+  var slice = Array.prototype.slice
+    , nextTick
+    , Stream;
 
   /**
    * Module dependencies.
@@ -23,36 +24,19 @@ module.exports = function spark() {
     };
   }
 
-  // Object create shim
-  if ('undefined' === typeof Object.create) {
-    Object.create = function (o) {
-      function F() {}
-      F.prototype = o;
-      return new F();
-    };
+  function inherit(a, b) {
+    function F() {}
+    F.prototype = b.prototype;
+    a.prototype = new F();
+    a.prototype.constructor = a;
   }
-
-  // shortcut to slice
-  var slice = [].slice;
-
-  // White list events
-  var events = [
-    'open',
-    'error',
-    'online',
-    'offline',
-    'timeout',
-    'reconnect',
-    'reconnect scheduled',
-    'readyStateChange'
-  ];
 
   /**
    * `Spark` constructor.
    *
    * @constructor
    * @param {Multiplex} Multiplex instance.
-   * @param {String|Number} id
+   * @param {String|Number} id.
    * @param {primus.Spark} conn.
    * @api public
    */
@@ -76,8 +60,7 @@ module.exports = function spark() {
    * Inherits from `EventEmitter`.
    */
 
-  Spark.prototype = Object.create(Stream.prototype);
-  Spark.prototype.constructor = Spark;
+  inherit(Spark, Stream);
 
   /**
    * Initialise the Primus and setup all
@@ -87,44 +70,47 @@ module.exports = function spark() {
    */
 
   Spark.prototype.initialise = function initialise() {
-    var spark = this;
+    var listeners = []
+      , spark = this
+      , events = []
+      , i;
+
+    for (var ev in this.conn.reserved.events) {
+      if ('data' === ev || 'end' === ev) continue;
+      events.push(ev);
+    }
 
     // This listener must be registered before other ones
     // to make sure readyState is set when the others are called
-    spark.conn.on('readyStateChange', onreadystatechange);
+    this.conn.on('readyStateChange', onreadystatechange);
 
-    // connect to the actuall channel
+    this.conn.on('reconnect', onreconnect);
+    this.conn.on('open', onopen);
+
+    // Connect to the actual channel
     this.connect();
 
-    // Re-emit events from main connection.
-    for (var i = 0; i < events.length; i++) {
-      reemit(events[i]);
+    // Re-emit events from main connection
+    for (i = 0; i < events.length; i++) {
+      listeners.push(proxy(events[i]));
+      this.conn.on(events[i], listeners[i]);
     }
 
-    function reemit(ev) {
-      spark.conn.on(ev, onevs);
-
-      spark.on('end', function () {
-        spark.conn.removeListener(ev, onevs);
-      });
-
-      function onevs() {
-        spark.emit.apply(spark, [ev].concat(slice.call(arguments)));
-      }
-    }
-
-    spark.conn.on('open', onopen);
-
-    spark.conn.on('reconnect', onreconnect);
-
-    spark.on('end', function () {
+    this.on('end', function () {
       spark.conn.removeListener('readyStateChange', onreadystatechange);
-      spark.conn.removeListener('open', onopen);
       spark.conn.removeListener('reconnect', onreconnect);
+      spark.conn.removeListener('open', onopen);
+      for (i = 0; i < events.length; i++) {
+        spark.conn.removeListener(events[i], listeners[i]);
+      }
     });
 
     function onreadystatechange() {
       spark.readyState = spark.conn.readyState;
+    }
+
+    function onreconnect() {
+      spark.reconnect = true;
     }
 
     function onopen() {
@@ -132,8 +118,10 @@ module.exports = function spark() {
       spark.reconnect = false;
     }
 
-    function onreconnect() {
-      spark.reconnect = true;
+    function proxy(ev) {
+      return function emit() {
+        spark.emit.apply(spark, [ev].concat(slice.call(arguments)));
+      };
     }
 
     return this;

--- a/test/test.js
+++ b/test/test.js
@@ -339,37 +339,30 @@ describe('primus-multiplex', function (){
   });
 
   describe('cleaning up client events', function () {
-    var EVENTS = [
-        'error',
-        'open',
-        'online',
-        'offline',
-        'reconnect',
-        'reconnect scheduled',
-        'readyStateChange'
-      ];
+    Object.keys(Primus.createSocket().prototype.reserved.events).forEach(function (ev) {
+      if ('data' === ev || 'end' === ev) return;
 
-    EVENTS.forEach(function createTest(event) {
-      it('should remove the ' + event + ' listener when client disconnects', function (done) {
-        var a = primus.channel('a');
+      it('should remove the ' + ev + ' listener when client disconnects', function (done) {
         srv.listen(function () {
-          a.on('disconnection', function (spark) {
-            expect(cl.listeners(event)).to.have.length(eventCount);
+          var a = primus.channel('a');
+
+          a.on('disconnection', function () {
+            expect(cl.listeners(ev)).to.have.length(eventCount);
 
             done();
           });
+
+          var cl = client(srv, primus)
+            , eventCount = cl.listeners(ev).length
+            , ca = cl.channel('a');
+
+          ca.end();
         });
-
-        var cl = client(srv, primus)
-          , eventCount = cl.listeners(event).length
-          , ca = cl.channel('a');
-
-        ca.end();
       });
     });
   });
 
-  it('should `emit` close event when destroying a channel', function (done) {
+  it('should emit `close` event when destroying a channel', function (done) {
     var a = primus.channel('a');
     srv.listen(function () {
       a.on('connection', function (spark) {
@@ -383,7 +376,7 @@ describe('primus-multiplex', function (){
     });
   });
 
-  it('should `emit` readyStateChange event when readyState changes', function (done) {
+  it('should emit `readyStateChange` event when readyState changes', function (done) {
     var a = primus.channel('a');
     srv.listen(function () {
       var cl = client(srv, primus)
@@ -414,7 +407,8 @@ describe('primus-multiplex', function (){
       });
       var cl = client(srv, primus)
         , cla = cl.channel('a');
-      cla.on('data', function (data){
+      cla.on('data', function (data) {
+        expect(data).to.be('hi');
         done();
       });
     });


### PR DESCRIPTION
This makes use of Primus [reserved events](https://github.com/primus/primus/blob/a8e06bfa93565338ff7b0cd03ab307857e986160/primus.js#L419-L434) to build the list of events that need to be proxied.

I'm not sure what events should not be proxied. Right now I have only excluded `data` and `end` but maybe there are more, like `close` for example.