### PR TITLE
[fix] Faster data parsing

### DIFF
--- a/lib/client/multiplex.js
+++ b/lib/client/multiplex.js
@@ -45,10 +45,10 @@ module.exports = function multiplex(Spark) {
     var mp = this;
     this.conn.on('data', function ondata(data) {
       if (isArray(data)) {
-        var type = data.shift()
-          , id = data.shift()
-          , name = data.shift()
-          , payload = data.shift()
+        var type = data[0]
+          , id = data[1]
+          , name = data[2]
+          , payload = data.length === 4 ? data[3] : undefined
           , channel = mp.channels[name][id];
 
         if (!channel) return false;

--- a/lib/server/multiplex.js
+++ b/lib/server/multiplex.js
@@ -96,10 +96,10 @@ Multiplex.prototype.onconnection = function onconnection(conn) {
     if (!isArray(data)) return false;
 
     // Parse data to get required fields.
-    var type = data.shift()
-      , id = data.shift()
-      , name = data.shift()
-      , payload = data.shift()
+    var type = data[0]
+      , id = data[1]
+      , name = data[2]
+      , payload = data.length === 4 ? data[3] : undefined
       , channel = mp.channels[name];
 
     if (!channel) {


### PR DESCRIPTION
`shift()` modifies the incoming array which should be considered a bug (subsequent data listeners will get an empty array depending on where they are in the iteration order). It's also slow.

Testing on regular & out of bounds access (e.g. no `payload`, so data[3] doesn't exist), 10M iterations:

```
shift: 1618.473ms
index: 68.041ms
shift oob: 1607.713ms
index oob: 104.179ms
```
