### PR TITLE
Fix: connection list cleanup

### DIFF
--- a/lib/server/channel.js
+++ b/lib/server/channel.js
@@ -118,9 +118,19 @@ Channel.prototype.subscribe = function subscribe(conn, id) {
  * @api private
  */
 
-Channel.prototype.unsubscribe = function unsubscribe(id) {
+Channel.prototype.unsubscribe = function unsubscribe(id, shouldCleanup) {
   var spark = this.connections[id];
   if (spark && !spark.unsubscribed) {
+    if (shouldCleanup !== false) {
+      var theseChannels = spark.conn.channels[this.name];
+      var sparkIdx = theseChannels.indexOf(spark.id);
+      if (sparkIdx !== -1) {
+        theseChannels.splice(sparkIdx, 1);
+        if (theseChannels.length === 0) {
+          delete spark.conn.channels[this.name];
+        }
+      }
+    }
     spark.conn.emit('unsubscribe', this, spark);
     spark.unsubscribed = true;
     spark.end();

--- a/lib/server/channel.js
+++ b/lib/server/channel.js
@@ -113,7 +113,7 @@ Channel.prototype.subscribe = function subscribe(conn, id) {
  * Unsubscribe a connection from this `channel`.
  *
  * @param {String|Number} id The connection id.
- * @param {Boolean} ignore
+ * @param {Boolean} shouldCleanup If true, will clean up references in spark.
  * @return {Channel} this
  * @api private
  */
@@ -121,11 +121,16 @@ Channel.prototype.subscribe = function subscribe(conn, id) {
 Channel.prototype.unsubscribe = function unsubscribe(id, shouldCleanup) {
   var spark = this.connections[id];
   if (spark && !spark.unsubscribed) {
+    // Should we clean up the parent conn's channel list?
     if (shouldCleanup !== false) {
+      // This internal storage contains all the spark IDs connected to this
+      // channel name. We'll remove this spark's ID from it.
       var theseChannels = spark.conn.channels[this.name];
       var sparkIdx = theseChannels.indexOf(spark.id);
       if (sparkIdx !== -1) {
+        // Remove this spark ID from the channel list
         theseChannels.splice(sparkIdx, 1);
+        // If the channel list for this name is empty, remove the list
         if (theseChannels.length === 0) {
           delete spark.conn.channels[this.name];
         }
@@ -133,6 +138,9 @@ Channel.prototype.unsubscribe = function unsubscribe(id, shouldCleanup) {
     }
     spark.conn.emit('unsubscribe', this, spark);
     spark.unsubscribed = true;
+    // Ending the spark will cause it to write an unsubscription packet an emit
+    // an 'end' event. It will also call unsubscribe() again, but this will bail
+    // out due to the 'unsubscribed' flag.
     spark.end();
     delete this.connections[id];
   }

--- a/lib/server/spark.js
+++ b/lib/server/spark.js
@@ -149,7 +149,7 @@ Spark.readable('end', function end(data) {
   if (data) this.write(data);
   process.nextTick(this.emit.bind(this, 'end'));
   this.conn.write(packet.call(this, 'UNSUBSCRIBE'));
-  this.channel.unsubscribe(this.id);
+  this.channel.unsubscribe(this.id, false /* shouldCleanup */);
   return this;
 });
 

--- a/lib/server/spark.js
+++ b/lib/server/spark.js
@@ -149,6 +149,8 @@ Spark.readable('end', function end(data) {
   if (data) this.write(data);
   process.nextTick(this.emit.bind(this, 'end'));
   this.conn.write(packet.call(this, 'UNSUBSCRIBE'));
+  // Unsubscribe this spark from the channel. No need to
+  // do state cleanup as the entire parent connection is closing.
   this.channel.unsubscribe(this.id, false /* shouldCleanup */);
   return this;
 });

--- a/test/test.js
+++ b/test/test.js
@@ -113,6 +113,8 @@ describe('primus-multiplex', function (){
     primus.on('connection', function(spark) {
       spark.on('subscribe', function(channel, channelSpark) {
         spark.on('unsubscribe', function(channel, channelSpark) {
+          expect(channelSpark.conn.channels[channelSpark.id]).to.be(undefined);
+          expect(Object.keys(channelSpark.conn.channels).length).to.be(0);
           expect(channel.name).to.be('a');
           expect(channelSpark).to.be.ok();
           done();
@@ -499,7 +501,7 @@ describe('primus-multiplex', function (){
   });
 
   it('should emit `disconnection` event on all connected sparks when main ' +
-    ' connection closes on client', function (done) {
+     'connection closes on client', function (done) {
 
     var a = primus.channel('a')
       , b = primus.channel('b')

--- a/test/test.js
+++ b/test/test.js
@@ -113,6 +113,7 @@ describe('primus-multiplex', function (){
     primus.on('connection', function(spark) {
       spark.on('subscribe', function(channel, channelSpark) {
         spark.on('unsubscribe', function(channel, channelSpark) {
+          // Expect internal storage to no longer contain this id
           expect(channelSpark.conn.channels[channelSpark.id]).to.be(undefined);
           expect(Object.keys(channelSpark.conn.channels).length).to.be(0);
           expect(channel.name).to.be('a');


### PR DESCRIPTION
If a parent connection subscribes and unsubscribes to many channels while staying open, the `conn.channels[channelName]` list can become very long, making `forEach()` slow and chewing up memory. This patch will prune that list on an unsubscription.