### PR TITLE
Fix/namespace channels

### DIFF
--- a/lib/server/multiplex.js
+++ b/lib/server/multiplex.js
@@ -90,7 +90,7 @@ Multiplex.prototype.bind = function bind() {
 Multiplex.prototype.onconnection = function onconnection(conn) {
   var mp = this;
   conn.channels = {};
-  var idPrefix = conn.id + '_';
+  var idPrefix = conn.id + ':';
 
   conn.on('data', function ondata(data) {
 
@@ -98,7 +98,7 @@ Multiplex.prototype.onconnection = function onconnection(conn) {
 
     // Parse data to get required fields.
     var type = data[0]
-      , id = idPrefix + data[1]
+      , id = idPrefix + data[1] + ':' + data[2]
       , name = data[2]
       , payload = data.length === 4 ? data[3] : undefined
       , channel = mp.channels[name];

--- a/lib/server/multiplex.js
+++ b/lib/server/multiplex.js
@@ -90,6 +90,7 @@ Multiplex.prototype.bind = function bind() {
 Multiplex.prototype.onconnection = function onconnection(conn) {
   var mp = this;
   conn.channels = {};
+  var idPrefix = conn.id + '_';
 
   conn.on('data', function ondata(data) {
 
@@ -97,7 +98,7 @@ Multiplex.prototype.onconnection = function onconnection(conn) {
 
     // Parse data to get required fields.
     var type = data[0]
-      , id = data[1]
+      , id = idPrefix + data[1]
       , name = data[2]
       , payload = data.length === 4 ? data[3] : undefined
       , channel = mp.channels[name];

--- a/lib/server/spark.js
+++ b/lib/server/spark.js
@@ -30,6 +30,7 @@ function Spark(channel, conn, id) {
     , spark = this;
 
   writable('id', id);
+  writable('bareID', id.replace(conn.id + '_', ''));
   writable('conn', conn);
   writable('primus', channel);
   writable('channel', channel);
@@ -164,7 +165,7 @@ Spark.readable('end', function end(data) {
 function packet(ev, data) {
   var name = this.channel.name
     , type = this.channel.mp.packets[ev]
-    , pack = [type, this.id, name];
+    , pack = [type, this.bareID, name];
   if (data) pack.push(data);
   return pack;
 }

--- a/lib/server/spark.js
+++ b/lib/server/spark.js
@@ -5,7 +5,8 @@
  */
 
 var Stream = require('stream')
-  , predefine = require('predefine');
+  , predefine = require('predefine')
+  , escapeRegExp = require('escape-string-regexp');
 
 /**
  * Module export.
@@ -29,8 +30,16 @@ function Spark(channel, conn, id) {
   var writable = predefine(this, predefine.WRITABLE)
     , spark = this;
 
+  // Generate bare ID (random from primus uuid generation)
+  // by removing parent conn and channel namespacing.
+  var bareID = id
+  // Remove parent conn.id from beginning
+  .replace(new RegExp('^' + escapeRegExp(conn.id + ':')), '')
+  // Remove channel from end
+  .replace(new RegExp(escapeRegExp(':' + channel.name) + '$'), '');
+
   writable('id', id);
-  writable('bareID', id.replace(conn.id + '_', ''));
+  writable('bareID', bareID);
   writable('conn', conn);
   writable('primus', channel);
   writable('channel', channel);

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
   ],
   "license": "MIT",
   "dependencies": {
+    "escape-string-regexp": "^1.0.5",
     "eventemitter3": "1.2.x",
     "predefine": "0.1.x"
   },

--- a/test/test.js
+++ b/test/test.js
@@ -110,10 +110,10 @@ describe('primus-multiplex', function (){
   });
 
 
-  it('should have an id namespaced by its parent', function (done) {
+  it('should have an id namespaced by its parent and channel name', function (done) {
     primus.on('connection', function(spark) {
       spark.on('subscribe', function(channel, channelSpark) {
-        expect(channelSpark.id).to.equal(spark.id + '_' + channelSpark.bareID);
+        expect(channelSpark.id).to.equal(spark.id + ':' + channelSpark.bareID + ':' + channel.name);
         done();
       });
     });

--- a/test/test.js
+++ b/test/test.js
@@ -109,6 +109,20 @@ describe('primus-multiplex', function (){
     cl.channel('a');
   });
 
+
+  it('should have an id namespaced by its parent', function (done) {
+    primus.on('connection', function(spark) {
+      spark.on('subscribe', function(channel, channelSpark) {
+        expect(channelSpark.id).to.equal(spark.id + '_' + channelSpark.bareID);
+        done();
+      });
+    });
+    srv.listen();
+
+    var cl = client(srv, primus);
+    cl.channel('a');
+  });
+
   it('should fire unsubscribe upon client close', function (done) {
     primus.on('connection', function(spark) {
       spark.on('subscribe', function(channel, channelSpark) {


### PR DESCRIPTION
Namespace IDs so there is no possibility of collision.

Without this fix, a user could potentially cause an ID collision
with the parent or with other sparks held by other users, causing
hard-to-debug problems or even security issues.